### PR TITLE
pynumero requires numpy>=1.13

### DIFF
--- a/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_matrix.py
+++ b/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_matrix.py
@@ -12,13 +12,13 @@ import warnings
 import pyutilib.th as unittest
 
 SKIPTESTS=[]
-try:
+from pyomo.contrib.pynumero import numpy_available, scipy_available
+if numpy_available and scipy_available:
     import numpy as np
     from scipy.sparse import coo_matrix, bmat
-except ImportError:
-    SKIPTESTS.append("Pynumero needs scipy and numpy to run BlockMatrix tests")
-else:
     from pyomo.contrib.pynumero.sparse import BlockVector, BlockMatrix
+else:
+    SKIPTESTS.append("Pynumero needs scipy and numpy>=1.13.0 to run BlockMatrix tests")
 
 try:
     from mpi4py import MPI

--- a/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_vector.py
+++ b/pyomo/contrib/pynumero/sparse/tests/test_mpi_block_vector.py
@@ -10,14 +10,13 @@
 import pyutilib.th as unittest
 
 SKIPTESTS=[]
-
-try:
+from pyomo.contrib.pynumero import numpy_available, scipy_available
+if numpy_available and scipy_available:
     import numpy as np
     from scipy.sparse import coo_matrix, bmat
-except ImportError:
-    SKIPTESTS.append("Pynumero needs scipy and numpy to run BlockVector tests")
-else:
     from pyomo.contrib.pynumero.sparse import BlockVector
+else:
+    SKIPTESTS.append("Pynumero needs scipy and numpy>=1.13.0 to run BlockMatrix tests")
 
 try:
     from mpi4py import MPI


### PR DESCRIPTION
We should still use `numpy_available` and `scipy_available` from `Pyomo.contrib.pynumero` because there is actually a check on the version of numpy too. Hopefully, this will fix the last failing test. 

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
