### PR TITLE
Stale global in persistent solvers

### DIFF
--- a/pyomo/contrib/appsi/base.py
+++ b/pyomo/contrib/appsi/base.py
@@ -25,6 +25,7 @@ from pyomo.core.kernel.objective import minimize, maximize
 from pyomo.core.base import SymbolMap
 import weakref
 from io import StringIO
+from pyomo.core.staleflag import StaleFlagManager
 
 
 class TerminationCondition(enum.Enum):
@@ -154,6 +155,8 @@ class SolutionLoaderBase(abc.ABC):
         """
         for v, val in self.get_primals(vars_to_load=vars_to_load).items():
             v.set_value(val, skip_validation=True)
+        StaleFlagManager.mark_all_as_stale(delayed=True)
+        
 
     @abc.abstractmethod
     def get_primals(self, vars_to_load: Optional[Sequence[_GeneralVarData]] = None) -> Mapping[_GeneralVarData, float]:
@@ -486,6 +489,7 @@ class PersistentSolver(Solver):
         """
         for v, val in self.get_primals(vars_to_load=vars_to_load).items():
             v.set_value(val, skip_validation=True)
+        StaleFlagManager.mark_all_as_stale(delayed=True)
 
     @abc.abstractmethod
     def get_primals(self, vars_to_load: Optional[Sequence[_GeneralVarData]] = None) -> Mapping[_GeneralVarData, float]:

--- a/pyomo/contrib/appsi/solvers/cbc.py
+++ b/pyomo/contrib/appsi/solvers/cbc.py
@@ -20,6 +20,7 @@ import sys
 from typing import Dict
 from pyomo.common.config import ConfigValue, NonNegativeInt
 from pyomo.common.errors import PyomoException
+from pyomo.core.staleflag import StaleFlagManager
 
 
 logger = logging.getLogger(__name__)
@@ -169,6 +170,7 @@ class Cbc(PersistentSolver):
         self._writer.update_params()
 
     def solve(self, model, timer: HierarchicalTimer = None):
+        StaleFlagManager.mark_all_as_stale()
         avail = self.available()
         if not avail:
             raise PyomoException(f'Solver {self.__class__} is not available ({avail}).')

--- a/pyomo/contrib/appsi/solvers/gurobi.py
+++ b/pyomo/contrib/appsi/solvers/gurobi.py
@@ -25,6 +25,7 @@ from pyomo.contrib.appsi.base import (
     PersistentSolver, Results, TerminationCondition, MIPSolverConfig,
     PersistentBase, PersistentSolutionLoader
 )
+from pyomo.core.staleflag import StaleFlagManager
 
 logger = logging.getLogger(__name__)
 
@@ -298,6 +299,7 @@ class Gurobi(PersistentBase, PersistentSolver):
         return self._postsolve(timer)
 
     def solve(self, model, timer: HierarchicalTimer = None) -> Results:
+        StaleFlagManager.mark_all_as_stale()
         avail = self.available()
         if not avail:
             raise PyomoException(f'Solver {self.__class__} is not available ({avail}).')
@@ -782,6 +784,7 @@ class Gurobi(PersistentBase, PersistentSolver):
     def load_vars(self, vars_to_load=None, solution_number=0):
         for v, val in self.get_primals(vars_to_load=vars_to_load, solution_number=solution_number).items():
             v.set_value(val, skip_validation=True)
+        StaleFlagManager.mark_all_as_stale(delayed=True)
 
     def get_primals(self, vars_to_load=None, solution_number=0):
         if self._needs_updated:

--- a/pyomo/contrib/appsi/solvers/ipopt.py
+++ b/pyomo/contrib/appsi/solvers/ipopt.py
@@ -23,6 +23,7 @@ from typing import Dict
 from pyomo.common.config import ConfigValue, NonNegativeInt
 from pyomo.common.errors import PyomoException
 import os
+from pyomo.core.staleflag import StaleFlagManager
 
 
 logger = logging.getLogger(__name__)
@@ -237,6 +238,7 @@ class Ipopt(PersistentSolver):
         f.close()
 
     def solve(self, model, timer: HierarchicalTimer = None):
+        StaleFlagManager.mark_all_as_stale()
         avail = self.available()
         if not avail:
             raise PyomoException(f'Solver {self.__class__} is not available ({avail}).')

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -789,7 +789,7 @@ class CPLEXDirect(DirectSolver):
                         soln_constraints[con_name]["Slack"] = qudratic_slacks[i]
         elif self._load_solutions:
             if cpxprob.solution.get_solution_type() > 0:
-                self._load_vars()
+                self.load_vars()
 
                 if extract_reduced_costs:
                     self._load_rc()

--- a/pyomo/solvers/plugins/solvers/direct_or_persistent_solver.py
+++ b/pyomo/solvers/plugins/solvers/direct_or_persistent_solver.py
@@ -19,6 +19,7 @@ from pyomo.common.collections import ComponentMap, ComponentSet, Bunch
 from pyomo.common.tempfiles import TempfileManager
 import pyomo.opt.base.solvers
 from pyomo.opt.base.formats import ResultsFormat
+from pyomo.core.staleflag import StaleFlagManager
 
 
 class DirectOrPersistentSolver(OptSolver):
@@ -277,6 +278,7 @@ class DirectOrPersistentSolver(OptSolver):
         vars_to_load: list of Var
         """
         self._load_vars(vars_to_load)
+        StaleFlagManager.mark_all_as_stale(delayed=True)
 
     """ This method should be implemented by subclasses."""
     def warm_start_capable(self):

--- a/pyomo/solvers/plugins/solvers/gurobi_direct.py
+++ b/pyomo/solvers/plugins/solvers/gurobi_direct.py
@@ -727,7 +727,7 @@ class GurobiDirect(DirectSolver):
         elif self._load_solutions:
             if gprob.SolCount > 0:
 
-                self._load_vars()
+                self.load_vars()
 
                 if extract_reduced_costs:
                     self._load_rc()

--- a/pyomo/solvers/plugins/solvers/mosek_direct.py
+++ b/pyomo/solvers/plugins/solvers/mosek_direct.py
@@ -827,7 +827,7 @@ class MOSEKDirect(DirectSolver):
         elif self._load_solutions:
             if self.results.problem.number_of_solutions > 0:
 
-                self._load_vars()
+                self.load_vars()
 
                 if extract_reduced_costs:
                     self._load_rc()

--- a/pyomo/solvers/plugins/solvers/xpress_direct.py
+++ b/pyomo/solvers/plugins/solvers/xpress_direct.py
@@ -731,7 +731,7 @@ class XpressDirect(DirectSolver):
             if xprob_attrs.lpstatus == xp.lp_optimal and \
                     ((not is_mip) or (xprob_attrs.mipsols > 0)):
 
-                self._load_vars()
+                self.load_vars()
 
                 if extract_reduced_costs:
                     self._load_rc()


### PR DESCRIPTION
1. A few more updates to the use of `StaleFlagManager` in persistent solvers
2. Use the `StaleFlagManager` in Appsi.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
